### PR TITLE
add deprecation notice pointing to ignition-guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # Basics of Git
 
 > [!IMPORTANT]
-> This content has moved. The Version Control content from this repository is now part of [ignition-guides](https://ia-eknorr.github.io/ignition-guides/), the modern community resource for DevOps workflows with Ignition.
+> This repository is archived. The Version Control content has moved to [ignition-guides](https://ia-eknorr.github.io/ignition-guides/), the community resource for modern DevOps workflows with Ignition.
 >
 > Go directly to: **[Version Control Guide](https://ia-eknorr.github.io/ignition-guides/docs/guides/version-control/intro)**
->
-> This repository will be archived once the linked forum post is updated.
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Basics of Git
 
+> [!IMPORTANT]
+> This content has moved. The Version Control content from this repository is now part of [ignition-guides](https://ia-eknorr.github.io/ignition-guides/), the modern community resource for DevOps workflows with Ignition.
+>
+> Go directly to: **[Version Control Guide](https://ia-eknorr.github.io/ignition-guides/docs/guides/version-control/intro)**
+>
+> This repository will be archived once the linked forum post is updated.
+
 ## Table of Contents
 
 - [Basics of Git](#basics-of-git)


### PR DESCRIPTION
The Version Control content from this repo has been merged into [ignition-guides](https://ia-eknorr.github.io/ignition-guides/). This PR adds an obvious banner at the top of the README so anyone landing here via the [forum post](https://forum.inductiveautomation.com/t/guide-for-version-control-with-ignition/84004) gets redirected to the new home.

This repo will be archived once the forum post is updated.