### PR TITLE
bump node version for markdownlint compatibility

### DIFF
--- a/.github/workflows/repo-lint.yml
+++ b/.github/workflows/repo-lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '19.x'
+          node-version: '22'
       - name: Install dependencies
         run: |
           npm install -g markdownlint-cli


### PR DESCRIPTION
The markdownlint workflow was pinned to Node 19, which doesn't support the regex `v` flag used by newer markdownlint-cli dependencies. Bumping to Node 22 (LTS).